### PR TITLE
fix view and state path substring bug

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,4 +1,5 @@
 const vscode = require('vscode');
+const path = require('path');
 
 function sendToTerminal(command, currentPath) {
     let terminal = vscode.window.createTerminal();
@@ -10,34 +11,37 @@ function sendToTerminal(command, currentPath) {
 
 function activate(context) {
     let generateApp = vscode.commands.registerCommand('extension.generateApp', function (e) {
-        const currentPath = vscode.workspace.asRelativePath(e.fsPath);
-        if (currentPath.includes('view') || currentPath.includes('state')) {
+        const pathSplit = vscode.workspace.asRelativePath(e.fsPath).split(path.sep);
+
+        if (pathSplit.includes('view') || pathSplit.includes('state')) {
             vscode.window.showErrorMessage("Oops you tried to generate an app from inside a view/state folder");
             return;
         }
 
-        const pathToConfig = currentPath + "/config.json";
+        const pathToConfig = [...pathSplit, 'config.json'].join(path.sep);
         sendToTerminal("yarn generate", pathToConfig);
     });
 
     let generateView = vscode.commands.registerCommand('extension.generateView', function (e) {
-        const currentPath = vscode.workspace.asRelativePath(e.fsPath);
-        if (!currentPath.includes('view')) {
+        const pathSplit = vscode.workspace.asRelativePath(e.fsPath).split(path.sep);
+
+        if (!pathSplit.includes('view')) {
             vscode.window.showErrorMessage("Oops you tried to generate a view not from a view folder");
             return;
         }
 
-        sendToTerminal("yarn generate view", currentPath);
+        sendToTerminal("yarn generate view", pathSplit.join(path.sep));
     });
 
     let generateState = vscode.commands.registerCommand('extension.generateState', function (e) {
-        const currentPath = vscode.workspace.asRelativePath(e.fsPath);
-        if (!currentPath.includes('state')) {
+        const pathSplit = vscode.workspace.asRelativePath(e.fsPath).split(path.sep);
+        
+        if (!pathSplit.includes('state')) {
             vscode.window.showErrorMessage("Oops you tried to generate a state not from a state folder");
             return;
         }
 
-        sendToTerminal("yarn generate state", currentPath);
+        sendToTerminal("yarn generate state", pathSplit.join(path.sep));
     });
 
     context.subscriptions.push(generateApp, generateView, generateState);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "jira-frontend",
     "displayName": "Jira Frontend",
     "description": "Extension for all things Jira Frontend.",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "publisher": "Atlassian",
     "author": {
         "name": "Atlassian"


### PR DESCRIPTION
Folder names such as "overview" would not work as expected due to searching for "view" in entire path instead of "view" in the directory names of the path