### PR TITLE
Highlight colors from @atlaskit/theme

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,16 @@
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ]
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/test"
+            ]
         }
     ]
 }

--- a/atlaskit-color-highlight/README.md
+++ b/atlaskit-color-highlight/README.md
@@ -1,0 +1,15 @@
+# Highlight atlaskit colors
+
+```
+import { colors } @atlaskit/theme
+```
+
+This folder highlights colors from atlaskit!
+
+This is inspired (and reuses some come) by the vscode-colorize extension: https://github.com/KamiKillertO/vscode-colorize.
+
+The colors source code is here: https://bitbucket.org/atlassian/atlaskit-mk-2/src/master/packages/core/theme/src/colors.js
+
+And they are documented here: https://atlassian.design/guidelines/brand/color-1
+
+... but isn't it nice to see them directly in your editor?

--- a/atlaskit-color-highlight/colors.js
+++ b/atlaskit-color-highlight/colors.js
@@ -1,0 +1,76 @@
+/*
+ * Color detection and utilities
+ */
+
+'use strict';
+
+const {
+    workspace,
+} = require('vscode');
+
+const {
+    getInstalledPathSync
+} = require('get-installed-path')
+
+let atlaskitColors = null
+
+const Color = require('color');
+
+const IMPORT_REGEX = /import ([a-zA-Z0-9]*)[, ]*{([\S ]+)colors([\S ]+)} from '@atlaskit\/theme';/;
+
+const importsColors = text => IMPORT_REGEX.test(text)
+
+const COLORS_REGEX = /colors\.[a-zA-Z0-9]+/g;
+
+/**
+ * Attempt to load the @atlaskit/theme package
+ * so that we can read the colors directly from it instead of hardcoding here
+ */
+function loadAtlaskitColors() {
+    if (atlaskitColors) { return atlaskitColors }
+    // require from the project workspace! this extension does not have @atlaskit/theme bundled
+    const atlaskitThemePath = getInstalledPathSync('@atlaskit/theme', {
+        local: true,
+        // !!! Uses first workspace !!! this may break with multiple. Let's assume nobody uses that ¯\_(ツ)_/¯
+        cwd: workspace.workspaceFolders[0].uri.path
+    })
+    // this may throw and if it throws it displays a bubble in VSCode so that users can report the bug!
+    const atlaskitTheme = require(atlaskitThemePath)
+    atlaskitColors = atlaskitTheme.colors
+    return atlaskitColors
+}
+
+const atlaskitColorToCssColor = (akColors, atlaskitColorAsString) => {
+    const withoutPrefix = atlaskitColorAsString.replace(/^colors\./, '')
+    return akColors[withoutPrefix]
+}
+
+const extractColorsUsage = (line, akColors = loadAtlaskitColors()) => {
+    const colors = []
+    let match = null
+    while ((match = COLORS_REGEX.exec(line)) !== null) {
+        const color = match[0]
+        colors.push({
+            color,
+            cssColor: atlaskitColorToCssColor(akColors, color),
+            startIndex: match.index,
+        })
+    }
+    return colors
+}
+
+const WHITE = '#FFFFFF';
+const BLACK = '#000000';
+
+function generateOptimalTextColor(colorAsString) {
+    const color = Color(colorAsString)
+    if (color.isLight()) {
+        return BLACK;
+    } else {
+        return WHITE;
+    }
+}
+
+exports.importsColors = importsColors
+exports.extractColorsUsage = extractColorsUsage
+exports.generateOptimalTextColor = generateOptimalTextColor

--- a/atlaskit-color-highlight/decoration.js
+++ b/atlaskit-color-highlight/decoration.js
@@ -1,0 +1,53 @@
+/*
+ * Abstracting away the create / enable / disable / delete differences of the vanilla TextEditorDecoration.
+ */
+
+'use strict';
+
+const {
+    window,
+    Range,
+    Position
+} = require('vscode');
+
+const { generateOptimalTextColor } = require('./colors')
+
+module.exports = class Decoration {
+
+    constructor(editor, colorsUsage, lineIndex) {
+
+        this._editor = editor
+
+        this._decoration = window.createTextEditorDecorationType({
+            borderWidth: '1px',
+            borderStyle: 'solid',
+            borderColor: colorsUsage.cssColor,
+            backgroundColor: colorsUsage.cssColor,
+            color: generateOptimalTextColor(colorsUsage.cssColor)
+        });
+
+
+        const startPosition = new Position(lineIndex, colorsUsage.startIndex)
+        const endPosition = new Position(lineIndex, colorsUsage.startIndex + colorsUsage.color.length)
+        this._decorationOptions = {
+            range: new Range(startPosition, endPosition),
+            hoverMessage: colorsUsage.cssColor,
+        }
+        
+        this.enable()
+    }
+
+    enable() {
+        this._editor.setDecorations(this._decoration, [this._decorationOptions])
+    }
+
+    disable() {
+        // https://github.com/Microsoft/vscode-extension-samples/issues/22#issuecomment-321555992
+        this._editor.setDecorations(this._decoration, [])
+    }
+
+    delete() {
+        this._decoration.dispose()
+    }
+
+}

--- a/atlaskit-color-highlight/index.js
+++ b/atlaskit-color-highlight/index.js
@@ -1,0 +1,241 @@
+/*
+ * This file contains VSCode extension lifecycle hooks and stitches the whole thing together.
+ */
+
+'use strict';
+
+// populated in function readConfiguration()
+const config = {}
+
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const {
+    window,
+    workspace,
+} = require('vscode');
+
+const {
+    importsColors,
+    extractColorsUsage,
+} = require('./colors')
+
+const Decoration = require('./decoration')
+
+const extension = {
+    usesColors: false, // if (file imports {colors} from @atlaskit/theme) => true, else false
+    editor: window.activeTextEditor, // TextEditor
+    currentSelection: [], // number[] array of lines
+    decorations: new Map(), // Map<lineIndex: number, decoration: Decoration>
+    lineCount: 0,
+}
+
+/**
+ * Colorize all visible text editors. Use when initializing the extension
+ */
+function colorizeVisibleTextEditors() {
+    window.visibleTextEditors.forEach(colorize)
+}
+
+/**
+ * 
+ * @param {TextDocument} document 
+ * @return {boolean} true if supported
+ */
+function canColorize(document) {
+    return document.languageId === 'javascript' && document.fileName.endsWith('.js')
+}
+
+/**
+ * @param {TextEditor} editor 
+ * @param {number} lineIndex
+ * @return {function} iterator over extracted color usages
+ */
+const highlight = (editor, lineIndex) => colorsUsage => {
+    const decoration = new Decoration(editor, colorsUsage, lineIndex)
+    updateDecorationMap(extension.decorations, lineIndex, decoration)
+}
+
+/**
+ * Set or concat the decorations array
+ * @param {Map<number, Decoration[]>} map 
+ * @param {number} line 
+ * @param {Decoration} decoration 
+ */
+function updateDecorationMap(map, line, decoration) {
+    if (map.has(line)) {
+        map.set(line, map.get(line).concat([decoration]));
+    } else {
+        map.set(line, [decoration]);
+    }
+}
+
+/**
+ * Initialize and decorate single text editor
+ * @param {TextEditor} editor 
+ */
+function colorize(editor) {
+    if (!editor || !canColorize(editor.document)) {
+        return
+    }
+    extension.editor = editor
+    extension.currentSelection = editor.selections.map(selection => selection.active.line)
+    extension.lineCount = editor.document.lineCount
+    // TODO cache here?
+    extension.decorations.clear()
+    const text = editor.document.getText()
+    const fileLines = text.split(/\n/)
+    extension.usesColors = false
+    // let's assume that imports are at the beginning of a file
+    let lineIndex = 0
+    for (; lineIndex < fileLines.length; lineIndex++) {
+        if (importsColors(fileLines[lineIndex])) {
+            extension.usesColors = true
+            break
+        }
+    }
+
+    if (!extension.usesColors) {
+        // this file does not import colors from @atlaskit/theme => nothing to do here
+        return
+    }
+
+    // let's assume that usage of colors.* _always comes after import_
+    extractColors(editor, lineIndex, fileLines.length)
+
+}
+
+/**
+ * Extract all colors between two lines and add all decorations
+ * @param {TextEditor} editor
+ * @param {number} firstLine
+ * @param {number} lastLine
+ */
+function extractColors(editor, firstLine, lastLine) {
+    const lines = editor.document.getText().split(/\n/)
+    for (let i = firstLine; i <= lastLine; i++) {
+        const extracted = extractColorsUsage(lines[i])
+        extracted.forEach(highlight(editor, i))
+    }
+}
+
+function handleChangeActiveTextEditor(editor) {
+    colorize(editor)
+}
+
+/**
+ * 
+ * @param {TextEditorSelectionChangeEvent} event 
+ */
+function handleTextSelectionChange(event) {
+    if (!config.isHideCurrentLineDecorations || event.textEditor !== extension.editor) {
+        return
+    }
+
+    // enable everything that was disabled before
+    extension.currentSelection.forEach(line => {
+        const decorations = extension.decorations.get(line)
+        if (decorations) {
+            decorations.forEach(_ => _.enable())
+        }
+    })
+
+    // disable decorations on active lines so that user can better see what they're typing
+    const selectedLines = event.selections.map(_ => _.active.line);
+    selectedLines.forEach(line => {
+        let decoration
+        // disable decoration on selected line
+        if (decoration = extension.decorations.get(line)) {
+            // this is an array because there can be multiple decorations on single line
+            decoration.forEach(_ => {
+                _.disable()
+            })
+        }
+    })
+
+    // save selected lines so that we can re-enable the disabled decorations later
+    extension.currentSelection = selectedLines
+}
+
+/**
+ * 
+ * @param {TextDocumentContentChangeEvent[]} contentChanges 
+ */
+function updateDecorations(contentChanges) {
+    contentChanges.forEach(change /* : TextDocumentContentChangeEvent */ => {
+
+        // first remove all decorations on changed lines
+        // _remove_, not disable! the text may have changed so the decorations may no longer apply
+        const startLine = change.range.start.line
+        let endLine = change.range.end.line
+        for (let i = startLine; i <= endLine; i++) {
+            if (extension.decorations.has(i)) {
+                extension.decorations.get(i).forEach(_ => _.delete())
+                extension.decorations.set(i, [])
+            }
+        }
+
+        // now regenerate all decorations on changed lines
+        const addedNewlinesMatch = change.text.match(/\n/g)
+        if (addedNewlinesMatch) {
+            // if multiple new lines have been added (paste, or undo, ...) VSCode reports startLine === endLine
+            // which is not we want.
+            // We want to add the count of added lines so that extractColors() finds colors.* usage in those added lines too
+            endLine += addedNewlinesMatch.length
+        }
+        extractColors(extension.editor, startLine, endLine)
+
+    })
+}
+
+/**
+ * 
+ * @param {TextDocumentChangeEvent} event 
+ */
+function handleChangeTextDocument(event) {
+    if (extension.editor && event.document.fileName === extension.editor.document.fileName) {
+        extension.editor = window.activeTextEditor
+        updateDecorations(event.contentChanges, extension)
+    }
+}
+
+function handleConfigurationChanged() {
+    readConfiguration()
+    clear()
+    colorizeVisibleTextEditors()
+}
+
+function clear() {
+    extension.decorations.clear()
+    extension.currentSelection.length = 0
+    extension.disabledDecorations.length = 0
+    extension.editor = null
+}
+
+function readConfiguration() {
+    // not configurable until somebody asks for it
+    config.isHideCurrentLineDecorations = true
+}
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+function activate(context) {
+    // This code will only be executed once when your extension is activated
+    readConfiguration()
+    initEventListeners(context)
+    colorizeVisibleTextEditors()
+}
+
+function initEventListeners(context) {
+    window.onDidChangeTextEditorSelection(handleTextSelectionChange, null, context.subscriptions);
+    // workspace.onDidCloseTextDocument(handleCloseOpen, null, context.subscriptions);
+    // workspace.onDidSaveTextDocument(handleCloseOpen, null, context.subscriptions);
+    window.onDidChangeActiveTextEditor(handleChangeActiveTextEditor, null, context.subscriptions);
+    workspace.onDidChangeTextDocument(handleChangeTextDocument, null, context.subscriptions);
+    workspace.onDidChangeConfiguration(handleConfigurationChanged, null, context.subscriptions);
+}
+
+exports.activate = activate;
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+exports.deactivate = deactivate;

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,8 @@
 const vscode = require('vscode');
 const path = require('path');
 
+const akColorsHighlight = require('./atlaskit-color-highlight')
+
 function sendToTerminal(command, currentPath) {
     let terminal = vscode.window.createTerminal();
     terminal.show();
@@ -45,9 +47,12 @@ function activate(context) {
     });
 
     context.subscriptions.push(generateApp, generateView, generateState);
+
+    akColorsHighlight.activate(context)
 }
 exports.activate = activate;
 
 function deactivate() {
+    akColorsHighlight.deactivate()
 }
 exports.deactivate = deactivate;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "activationEvents": [
         "onCommand:extension.generateApp",
         "onCommand:extension.generateView",
-        "onCommand:extension.generateState"
+        "onCommand:extension.generateState",
+        "onLanguage:javascript"
     ],
     "main": "./extension",
     "repository": {
@@ -82,10 +83,15 @@
         ]
     },
     "scripts": {
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
         "vscode": "^1.1.6",
         "@types/node": "^7.0.43"
+    },
+    "dependencies": {
+        "color": "^3.0.0",
+        "get-installed-path": "^4.0.8"
     }
 }

--- a/test/colors.test.js
+++ b/test/colors.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const assert = require('assert')
+
+const { importsColors, extractColorsUsage } = require('../atlaskit-color-highlight/colors')
+
+suite('IMPORT_REGEX', () => {
+    test('should recognize import colors', () => {
+        const line = "import { colors } from '@atlaskit/theme';"
+        assert.equal(importsColors(line), true);
+    })
+
+    test('should recognize import multiple variables', () => {
+        const line = "import { colors, typography } from '@atlaskit/theme';"
+        assert.equal(importsColors(line), true);
+    })
+
+    test('should recognize default import with colors', () => {
+        const line = "import theme, { colors } from '@atlaskit/theme';"
+        assert.equal(importsColors(line), true);
+    })
+
+    test('should recognize default import with multiple variables', () => {
+        const line = "import theme, { colors, typography } from '@atlaskit/theme';"
+        assert.equal(importsColors(line), true);
+    })
+
+    test('should not recognize import variables without colors', () => {
+        const line = "import { typography, gridUnit } from '@atlaskit/theme';"
+        assert.equal(importsColors(line), false);
+    })
+
+    test('should not recognize default import without colors', () => {
+        const line = "import theme from '@atlaskit/theme';"
+        assert.equal(importsColors(line), false);
+    })
+})
+
+suite('extractColorsUsage', () => {
+
+    test('should return empty array when line does not use colors.', () => {
+        const line = '    border-radius: ${fieldBorderRadius};'
+        assert.deepStrictEqual(extractColorsUsage(line, {}), [])
+    })
+
+    test('should return match for single usage', () => {
+        const line = '    background: ${colors.N30};'
+        assert.deepStrictEqual(extractColorsUsage(line, { 'N30': '#bada55' }), [{
+            color: 'colors.N30',
+            "cssColor": "#bada55",
+            startIndex: 18,
+        }])
+    })
+
+    test('should return match for multiple uses', () => {
+        const line = '    box-shadow: 0 1px 1px ${colors.N50A}, 0 0 1px ${colors.N30A};'
+        assert.deepStrictEqual(extractColorsUsage(line, { 'N50A': '#bada55', 'N30A': 'green' }), [{
+            color: 'colors.N50A',
+            "cssColor": "#bada55",
+            startIndex: 28,
+        }, {
+            color: 'colors.N30A',
+            "cssColor": "green",
+            startIndex: 52,
+        }])
+    })
+
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+const testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.js (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,9 +235,37 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
+color-convert@^1.9.1:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.2.tgz#49881b8fba67df12a96bdf3f56c0aab9e7913147"
+  dependencies:
+    color-name "1.1.1"
+
+color-name@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.1.tgz#4b1415304cf50028ea81643643bd82ea05803689"
+
+color-name@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+
+color-string@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.2.tgz#26e45814bc3c9a7cbd6751648a41434514a773a9"
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color-support@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
+
+color@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
 
 combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
@@ -366,6 +394,12 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 extend-shallow@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-1.1.4.tgz#19d6bf94dfc09d76ba711f39b872d21ff4dd9071"
@@ -493,6 +527,12 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
+get-installed-path@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/get-installed-path/-/get-installed-path-4.0.8.tgz#a4fee849f5f327c12c551bb37477acd5151e5f7d"
+  dependencies:
+    global-modules "1.0.0"
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -552,6 +592,24 @@ glob@^5.0.3:
     minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-modules@1.0.0, global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 glogg@^1.0.0:
   version "1.0.1"
@@ -736,6 +794,12 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
+homedir-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
+  dependencies:
+    parse-passwd "^1.0.0"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -762,6 +826,14 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+ini@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+is-arrayish@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.1.tgz#c2dfc386abaa0c3e33c48db3fe87059e69065efd"
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -859,6 +931,10 @@ is-valid-glob@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-0.3.0.tgz#d4b55c69f51886f9b65c70d6c2622d37e29f48fe"
 
+is-windows@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 is@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
@@ -870,6 +946,10 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -1174,6 +1254,10 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
@@ -1371,6 +1455,13 @@ requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resolve-dir@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
+
 rimraf@2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -1384,6 +1475,12 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
 semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -1688,6 +1785,12 @@ vscode@^1.1.6:
     source-map-support "^0.5.0"
     url-parse "^1.1.9"
     vinyl-source-stream "^1.1.0"
+
+which@^1.2.14:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  dependencies:
+    isexe "^2.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This is what it looks like (notice the coloured backgrounds and hash in hover tooltip) :

![image](https://user-images.githubusercontent.com/1100170/41519433-6e959a26-730b-11e8-870b-0d5dd663c6b8.png)

I'm open to ideas. Like: allow to turn this off in configuration? Gutter icons instead of background? Colours in intellisense suggestions?

Inspired by https://github.com/KamiKillertO/vscode-colorize
